### PR TITLE
detrend and column utils

### DIFF
--- a/mopy/core/spectrumgroup.py
+++ b/mopy/core/spectrumgroup.py
@@ -270,7 +270,7 @@ class SpectrumGroup(DataGroupBase):
             spreading_coefficient = self.stats["spreading_coefficient"]
 
         df = self.data.multiply(spreading_coefficient, axis=0)
-        return self.new_from_dict(data= df)
+        return self.new_from_dict(data=df)
 
     @_track_method
     def to_motion_type(self, motion_type: str):

--- a/mopy/core/statsgroup.py
+++ b/mopy/core/statsgroup.py
@@ -91,7 +91,7 @@ class _StatsGroup(GroupBase):
             df.loc[:, "starttime"] = df["starttime"] - start
         if end is not None:
             df.loc[:, "endtime"] = df["endtime"] + end
-        return self.new_from_dict({"data": df})
+        return self.new_from_dict(data=df)
 
 
 class StatsGroup(_StatsGroup):
@@ -632,7 +632,7 @@ class StatsGroup(_StatsGroup):
             df.loc[:, "starttime"] = df["starttime"] - start
         if end is not None:
             df.loc[:, "endtime"] = df["endtime"] + end
-        return self.new_from_dict({"data": df})
+        return self.new_from_dict(data=df)
 
     def add_mopy_metadata(self, df):
         """

--- a/mopy/core/tracegroup.py
+++ b/mopy/core/tracegroup.py
@@ -70,6 +70,7 @@ class _TraceGroup(DataGroupBase):
         Make the dataframe containing time series data.
         """
         sampling_rate = self.sampling_rate
+        assert sampling_rate is not None
 
         # figure out with streams are fractured and drop them
         good_st, new_ind = self._filter_stream_array(st_array)
@@ -221,7 +222,7 @@ class _TraceGroup(DataGroupBase):
         ----------
         fill_value
         """
-        return self.new_from_dict({"data": self.data.fillna(fill_value)})
+        return self.new_from_dict(data=self.data.fillna(fill_value))
 
 
 class TraceGroup(_TraceGroup):

--- a/tests/test_core/test_trace_group.py
+++ b/tests/test_core/test_trace_group.py
@@ -67,6 +67,43 @@ class TestBasics:
             TraceGroup(node_stats_group_no_picks, node_st, motion_type="velocity")
 
 
+class TestDetrend:
+
+    def _assert_zero_meaned(self, df):
+        """ assert that the dataframe's columns have zero-mean. """
+        mean = df.mean(axis=1)
+        np.testing.assert_almost_equal(mean.values, 0)
+
+    @pytest.fixture
+    def tg_with_nan(self, node_trace_group):
+        """ set some NaN value to node_trace_group. """
+        df = node_trace_group.data.copy()
+        # make jagged NaN stuffs
+        df.loc[:, df.columns[-4:]] = np.NaN
+        df.loc[df.index[0], df.columns[-6]:] = np.NaN
+        return node_trace_group.new_from_dict(data=df)
+
+    """ Tests for removing the trend of data. """
+    def test_constant_detrend(self, node_trace_group):
+        out = node_trace_group.detrend(type='constant')
+        self._assert_zero_meaned(out.data)
+
+    def test_constant_with_nan(self, tg_with_nan):
+        """ set some NaN values at end of trace and return. """
+        out = tg_with_nan.detrend(type='constant')
+        self._assert_zero_meaned(out.data)
+
+    def test_linear_detrend(self, node_trace_group):
+        """ make sure linear detrend works. """
+        # out = node_trace_group.detrend('linear')
+        # self._assert_zero_meaned(out.data)
+
+    def test_linear_with_nan(self, tg_with_nan):
+        """ ensure NaNs don't mess up linear detrend. """
+        breakpoint()
+        out = tg_with_nan.detrend('linear')
+        breakpoint()
+
 class TestToSpectrumGroup:
     """ Tests for converting the TraceGroup to SpectrumGroups. """
 

--- a/tests/test_core/test_trace_group.py
+++ b/tests/test_core/test_trace_group.py
@@ -68,7 +68,6 @@ class TestBasics:
 
 
 class TestDetrend:
-
     def _assert_zero_meaned(self, df):
         """ assert that the dataframe's columns have zero-mean. """
         mean = df.mean(axis=1)
@@ -77,32 +76,33 @@ class TestDetrend:
     @pytest.fixture
     def tg_with_nan(self, node_trace_group):
         """ set some NaN value to node_trace_group. """
-        df = node_trace_group.data.copy()
+        df = node_trace_group.data.copy() + 1
         # make jagged NaN stuffs
         df.loc[:, df.columns[-4:]] = np.NaN
-        df.loc[df.index[0], df.columns[-6]:] = np.NaN
+        df.loc[df.index[0], df.columns[-6] :] = np.NaN
         return node_trace_group.new_from_dict(data=df)
 
     """ Tests for removing the trend of data. """
+
     def test_constant_detrend(self, node_trace_group):
-        out = node_trace_group.detrend(type='constant')
+        out = node_trace_group.detrend(type="constant")
         self._assert_zero_meaned(out.data)
 
     def test_constant_with_nan(self, tg_with_nan):
         """ set some NaN values at end of trace and return. """
-        out = tg_with_nan.detrend(type='constant')
+        out = tg_with_nan.detrend(type="constant")
         self._assert_zero_meaned(out.data)
 
     def test_linear_detrend(self, node_trace_group):
         """ make sure linear detrend works. """
-        # out = node_trace_group.detrend('linear')
-        # self._assert_zero_meaned(out.data)
+        out = node_trace_group.detrend("linear")
+        self._assert_zero_meaned(out.data)
 
     def test_linear_with_nan(self, tg_with_nan):
         """ ensure NaNs don't mess up linear detrend. """
-        breakpoint()
-        out = tg_with_nan.detrend('linear')
-        breakpoint()
+        out = tg_with_nan.detrend("linear")
+        self._assert_zero_meaned(out.data)
+
 
 class TestToSpectrumGroup:
     """ Tests for converting the TraceGroup to SpectrumGroups. """


### PR DESCRIPTION
This does 3 things:

1. Adds a `detrend` method to dataframe group objects.
2. Renames `get_column_or_index` to just `get_columns`
3. Adds a `dropna` method to dataframe groups
4. Makes `new_from_dict` use keywords rather than a dict (a bit more ergonomic this way)

